### PR TITLE
Fixing configuration for LGA sites

### DIFF
--- a/static/observatory/metadata/codeMap.csv
+++ b/static/observatory/metadata/codeMap.csv
@@ -17,6 +17,7 @@ LAX05,CA,Los Angeles,Zayo,Southern California
 LGA01,NY,New York,Internap,New York
 LGA02,NY,New York,Cogent,New York
 LGA04,NY,New York,GTT,New York
+LGA05,NY,New York,Level3,New York
 MIA01,FL,Miami,Level3,Miami
 MIA02,FL,Miami,Cogent,Miami
 MIA03,FL,Miami,Tata,Miami

--- a/static/observatory/metadata/whitelist.txt
+++ b/static/observatory/metadata/whitelist.txt
@@ -46,9 +46,6 @@ lga02_cablevision
 lga02_comcast
 lga02_twc
 lga02_verizon
-lga03_cablevision
-lga03_twc
-lga03_verizon
 lga04_cablevision
 lga04_comcast
 lga04_twc
@@ -74,4 +71,3 @@ sea01_centurylink
 sea01_comcast
 sea02_centurylink
 sea02_comcast
-


### PR DESCRIPTION
Removing lga03 from whitelist because it is too far from sample size
thresholds.
Adding metadata for lga05.