### PR TITLE
Adding better error handling for corrupt Telescope data files

### DIFF
--- a/convert_from_telescope/telescope_data_parser.py
+++ b/convert_from_telescope/telescope_data_parser.py
@@ -35,6 +35,15 @@ except ImportError:
                    'Please verify all submodules are checked out.'))
 
 
+class Error(Exception):
+  pass
+
+
+class ParseFailedError(Error):
+  """Error thrown when parsing Telescope data fails."""
+  pass
+
+
 def _parse_filename_for_metadata(file_path):
   """Parses a telescope file path for metadata.
 
@@ -136,8 +145,13 @@ class SingleTelescopeResultReader(TelescopeResultReader):
     self._result_filename = result_filename
 
   def _read_rows(self):
-    with open(self._result_filename, 'r') as data_file:
-      return _parse_data_file(data_file)
+    try:
+      with open(self._result_filename) as data_file:
+        return _parse_data_file(data_file)
+    except csv.Error as e:
+      raise ParseFailedError(
+          'Failed to parse Telescope CSV file: %s\nError: %s' % (
+              self._result_filename, e))
 
   def get_metadata(self):
     return _parse_filename_for_metadata(self._result_filename)

--- a/convert_from_telescope/telescope_data_parser_test.py
+++ b/convert_from_telescope/telescope_data_parser_test.py
@@ -96,13 +96,11 @@ class SingleTelescopeResultReaderTest(unittest.TestCase):
     self.assertListEqual(results_expected, results_actual)
 
   @mock.patch('__builtin__.open')
-  def test_iter_when_file_contains_null_byte(self, mock_open):
-    file_contents = '\n'.join((
-        '1416501638,\0x0015.9014',
-        '1326589323,109.11934',
-        '1327712523,80.11242'))
-    mock_input_file = io.BytesIO(file_contents)
-    mock_open.return_value = mock_input_file
+  def test_iter_when_file_contains_null_byte_raise_ParseFailedError(self,
+                                                                    mock_open):
+    """A NULL byte in Telescope data should yield a ParseFailedError."""
+    file_contents = '1416501638,\0x0015.9014'
+    mock_open.return_value = io.BytesIO(file_contents)
     with self.assertRaises(telescope_data_parser.ParseFailedError):
       reader = telescope_data_parser.SingleTelescopeResultReader(
           'mock_filename.csv')

--- a/convert_from_telescope/telescope_data_parser_test.py
+++ b/convert_from_telescope/telescope_data_parser_test.py
@@ -95,6 +95,27 @@ class SingleTelescopeResultReaderTest(unittest.TestCase):
     results_actual = [result_row for result_row in reader]
     self.assertListEqual(results_expected, results_actual)
 
+  @mock.patch('__builtin__.open')
+  def test_iter_when_file_contains_null_byte(self, mock_open):
+    file_contents = '\n'.join((
+        '1416501638,\0x0015.9014',
+        '1326589323,109.11934',
+        '1327712523,80.11242'))
+    mock_input_file = io.BytesIO(file_contents)
+    mock_open.return_value = mock_input_file
+    with self.assertRaises(telescope_data_parser.ParseFailedError):
+      reader = telescope_data_parser.SingleTelescopeResultReader(
+          'mock_filename.csv')
+      results_actual = [result_row for result_row in reader]
+
+  @mock.patch('__builtin__.open')
+  def test_iter_when_file_open_fails(self, mock_open):
+    """When opening the file fails, just pass through the original IOError."""
+    mock_open.side_effect = IOError('Mock IOError')
+    with self.assertRaises(IOError):
+      reader = telescope_data_parser.SingleTelescopeResultReader(
+          'non_existent_file.csv')
+      results_actual = [result_row for result_row in reader]
 
 class MergedTelescopeResultReaderTest(unittest.TestCase):
 


### PR DESCRIPTION
This adds a specific exception for the case where parsing Telescope data
fails, as opposed to just failing with a csv.Error and no indication of
which file failed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-observatory/88)
<!-- Reviewable:end -->
