### PR TITLE
Updating Observatory converter for compatibility with Telescope v1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "convert_from_telescope/telescope"]
 	path = convert_from_telescope/telescope
-	url = https://github.com/m-lab-tools/telescope.git
+	url = https://github.com/m-lab/telescope.git

--- a/convert_from_telescope/convert.py
+++ b/convert_from_telescope/convert.py
@@ -17,13 +17,9 @@
 
 import logging
 import os
-import sys
 
 try:
-  sys.path.insert(1,
-                  os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                               './telescope')))
-  import telescope.utils
+  import telescope.telescope.utils as telescope_utils
 except ImportError:
   raise Exception(('Could not find Telescope library. '
                    'Please verify all submodules are checked out.'))
@@ -63,7 +59,7 @@ def _generate_output_path(group_key, output_dir, output_type):
     characters).
   """
   filename = '%s_%s.csv' % (group_key, output_type)
-  filename = telescope.utils.strip_special_chars(filename)
+  filename = telescope_utils.strip_special_chars(filename)
   return os.path.join(output_dir, filename)
 
 

--- a/convert_from_telescope/telescope_data_parser.py
+++ b/convert_from_telescope/telescope_data_parser.py
@@ -21,15 +21,11 @@ import csv
 import datetime
 import os
 import re
-import sys
 
 import pytz
 
 try:
-  sys.path.insert(1,
-                  os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                               './telescope')))
-  import telescope.utils
+  import telescope.telescope.utils as telescope_utils
 except ImportError:
   raise Exception(('Could not find Telescope library. '
                    'Please verify all submodules are checked out.'))
@@ -80,14 +76,14 @@ def _parse_filename_for_metadata(file_path):
   parsed['start_date_string'] = match.group(1)
   parsed['duration_string'] = match.group(2)
   parsed['site_name'] = match.group(3)
-  parsed['isp'] = telescope.utils.strip_special_chars(match.group(4))
+  parsed['isp'] = telescope_utils.strip_special_chars(match.group(4))
   parsed['metric_name'] = match.group(5)
 
   parsed['metro'] = parsed['site_name'][:3]
 
   start_date_no_tz = datetime.datetime.strptime(parsed['start_date_string'],
                                                 '%Y-%m-%d-%H%M%S')
-  parsed['start_date'] = telescope.utils.make_datetime_utc_aware(
+  parsed['start_date'] = telescope_utils.make_datetime_utc_aware(
       start_date_no_tz)
 
   return parsed


### PR DESCRIPTION
There are a few instances where Observatory depends on the Telescope library. We changed around some paths going from Telescope 1.0 to 1.1 so this syncs up Observatory with Telescope 1.1 and fixes the paths.