### PR TITLE
Adding a travis config for unit tests and code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ install:
     - pip install -r test-requirements.txt
     - pip install coveralls
 script:
+    # Run unit tests and calculate code coverage.
+    # Note that we exclude the telescope/ directory from coverage as it is a
+    # submodule of the repo and so should not be included in this repo's code
+    # coverage metrics.
     - coverage run --omit="convert_from_telescope/telescope/*" --source convert_from_telescope -m unittest discover
 after_success:
     coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+install:
+    - pip install -r requirements.txt
+    - pip install -r test-requirements.txt
+    - pip install coveralls
+script:
+    - coverage run --source convert_from_telescope -m unittest discover
+after_success:
+    coveralls
+
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
     - pip install -r test-requirements.txt
     - pip install coveralls
 script:
-    - coverage run --source convert_from_telescope -m unittest discover
+    - coverage run --omit="convert_from_telescope/telescope/*" --source convert_from_telescope -m unittest discover
 after_success:
     coveralls
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 mlab-observatory
 ================
 
+[![Build
+Status](https://travis-ci.org/m-lab/mlab-observatory.svg?branch=master)](https://travis-ci.org/m-lab/mlab-observatory)
+[![Coverage
+Status](https://coveralls.io/repos/m-lab/mlab-observatory/badge.svg?branch=master&service=github)](https://coveralls.io/github/m-lab/mlab-observatory?branch=master)
+
 # Setup
 
 To bootstrap the environment, run:


### PR DESCRIPTION
This change configures Travis CI and Coveralls for the Python code in the repo and adds the respective badges to the README.