### PR TITLE
Setting Travis config to a specific version of YAPF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
     - pip install -r requirements.txt
     - pip install -r test-requirements.txt
     - pip install coveralls
-    - pip install yapf
+    - pip install yapf==0.5.0
 script:
     # Run unit tests and calculate code coverage.
     # Note that we exclude the telescope/ directory from coverage as it is a


### PR DESCRIPTION
We just saw a bug in Telescope where YAPF changed out from under us and started causing build breaks.

https://github.com/m-lab/telescope/issues/76

Fortunately YAPF v0.4.0 and v0.5.0 format Observatory exactly the same, but we should fix the version so that we're using an explicit version of YAPF.